### PR TITLE
Add method to get match log data

### DIFF
--- a/pyfooty/src/club.py
+++ b/pyfooty/src/club.py
@@ -158,7 +158,6 @@ class Club(AbstractFooty):
 
         df = pd.DataFrame.from_dict(pre_df_dict)
 
-        import pdb; pdb.set_trace()
         return df
 
     def get_tables(self):

--- a/pyfooty/src/utils.py
+++ b/pyfooty/src/utils.py
@@ -26,3 +26,19 @@ def get_available_tables(url, name=None):
     all_divs = soup.findAll("div", {"class": "table_wrapper"})
     div = tuple([x.find("span")["data-label"] for x in all_divs])
     return div
+
+def get_matchlog_str(table_type):
+    """ Get valid strings to get matchlog data"""
+    matchlog_dict = {
+            "Scores & Fixtures": "schedule",
+            "Shooting": "shooting",
+            "Goalkeeping": "keeper",
+            "Passing": "passing",
+            "Pass Types": "passing_types",
+            "Goal and Shot Creation": "gca",
+            "Defensive Actions": "defense",
+            "Possession": "possession",
+            "Miscellaneous Stats": "misc",
+            }
+
+    return matchlog_dict[table_type]

--- a/pyfooty/tests/test_club.py
+++ b/pyfooty/tests/test_club.py
@@ -1,10 +1,9 @@
 import pytest
 from pyfooty.src.club import Club
 
+
 class TestClub(object):
-    @pytest.mark.parametrize(
-        "club_name", ("Chelsea", "Real Madrid", "Barcelona")
-    )
+    @pytest.mark.parametrize("club_name", ("Chelsea", "Real Madrid", "Barcelona"))
     def test_club_name(self, club_name):
         assert club_name in Club(club_name).name
 
@@ -16,6 +15,24 @@ class TestClub(object):
         club_obj = Club("Chelsea FC", 2019)
 
         assert len(club_obj.valid_tables) == 13
+
+    @pytest.mark.parametrize(
+        "table_type",
+        (
+            "Shooting",
+            "Scores & Fixtures",
+            "Goalkeeping",
+            "Passing",
+            "Pass Types",
+            "Goal and Shot Creation",
+            "Defensive Actions",
+            "Possession",
+            "Miscellaneous Stats",
+        ),
+    )
+    def test_club_matchlog(self, table_type):
+        club_obj = Club("Chelsea FC", 2019)
+        club_obj.get_matchlog(table_type)
 
     def test_club_float(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
Add `get_matchlog` method to get matchlog data from FBref.  Parsing this data is quite clunky right now.  I haven't figured out how to grab this nicely with beautiful soup so I have a dictionary in `utils` that will return the correct path to the matchlog data.  A simple test has been added to check that this method works.